### PR TITLE
DeviceTree: Add load_from_raw_pointer()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,11 +229,10 @@ impl DeviceTree {
 
     /// Load a device tree from a raw pointer. This should be used when the size of the device tree
     /// is unknown
-    pub fn load_from_raw_pointer(addr: *const u8) -> Result<DeviceTree, DeviceTreeError> {
-        let mut buffer: &[u8] =
-            unsafe { slice::from_raw_parts_mut(addr as *mut u8, Self::MIN_HEADER_SIZE) };
+    pub unsafe fn load_from_raw_pointer(addr: *const u8) -> Result<DeviceTree, DeviceTreeError> {
+        let mut buffer: &[u8] = slice::from_raw_parts_mut(addr as *mut u8, Self::MIN_HEADER_SIZE);
         let buffer_actual_size = buffer.read_be_u32(4)? as usize;
-        buffer = unsafe { slice::from_raw_parts_mut(addr as *mut u8, buffer_actual_size) };
+        buffer = slice::from_raw_parts_mut(addr as *mut u8, buffer_actual_size);
 
         return Self::load(buffer);
     }


### PR DESCRIPTION
Add a ``load_from_raw_pointer`` method to ``DeviceTree`` that will create a slice with the correct size before calling ``load()``. This is used when we don't know the real size of the fdt at compile time. Eg: Loaded from OpenSBI (RiscV)